### PR TITLE
fix for AttributeError 'x' in numpy.ndarray

### DIFF
--- a/starter-bots/python3/PythonStarterBot.py
+++ b/starter-bots/python3/PythonStarterBot.py
@@ -130,7 +130,7 @@ class StarterBot:
             obstacle_in_path = False
 
             for cell in line_points:
-                cell_type = self.get_cell_type(cell.x, cell.y)
+                cell_type = self.get_cell_type(cell[0], cell[1])
                 if cell_type is None:
                     continue
                 elif (cell_type == 'DIRT') or (cell_type == 'DEEP_SPACE'):


### PR DESCRIPTION
Fixes late game error that occurs because cell has no attribute 'x' or 'y', instead, index '0' and '1' are used.

Closes #49 