### PR TITLE
Fix

### DIFF
--- a/game-engine/game-rules.md
+++ b/game-engine/game-rules.md
@@ -85,6 +85,9 @@ The format of the Banana Bomb command is `banana x y`
     * You will be awarded score based on the damage done to all worms in this radius
   * The Banana bomb will destroy any dirt in the damage radius
     * You will be rewarded the same score as if you dug out all the affected dirt blocks
+    * If your opponent dug out 1 of these dirt blocks, your banana bomb will not get score for that block, since dig commands are executed before banana bomb commands 
+    * When both players throw a banana bomb onto the same area, both players will get score for the dirt blocks destroyed as if their banana bomb was the first to hit
+  * The Banana bomb will destroy any powerups in the damage radius
 * When a worm's health is 0 or lower, it will fall unconscious and be removed from the map 
 * Be careful! Friendly fire will damage your own worms
   *  You will be penalised with negative score based on the damage dealt
@@ -145,6 +148,7 @@ This implies the following regarding command interaction:
 * A worm can move into range of another worm's shot
 * A worm can move out of range of another worm's shot 
 * Two worms can dig open the same dirt cell in a single round
+* A worm can dig a block right before a banana bomb destroys that block
 
 ## Worm Profession
 

--- a/game-engine/src/commonMain/kotlin/za/co/entelect/challenge/game/engine/command/implementation/BananaCommand.kt
+++ b/game-engine/src/commonMain/kotlin/za/co/entelect/challenge/game/engine/command/implementation/BananaCommand.kt
@@ -74,8 +74,9 @@ class BananaCommand(val target: Point, val config: GameConfig) : WormsCommand {
                         return@loop // equivalent to continue
                     }
 
-                    if (cell.type == CellType.DIRT) {
+                    if (cell.type == CellType.DIRT || cell.destroyedInRound == gameMap.currentRound) {
                         cell.type = CellType.AIR
+                        cell.destroyedInRound = gameMap.currentRound
                         totalDirtDestroyed += 1
                     }
 

--- a/game-engine/src/commonMain/kotlin/za/co/entelect/challenge/game/engine/map/MapCell.kt
+++ b/game-engine/src/commonMain/kotlin/za/co/entelect/challenge/game/engine/map/MapCell.kt
@@ -9,11 +9,10 @@ class MapCell(var x: Int = -1,
 
     constructor(cellType: CellType = CellType.AIR) : this(type = cellType)
 
+    var destroyedInRound: Int? = null
     var occupier: Worm? = null
     var powerup: Powerup? = null
-
     val ipInfo = ImageProcessingInfo()
-
     val position get() = Point(x, y)
 
     fun isOccupied(): Boolean {

--- a/game-engine/src/jvmTest/kotlin/za/co/entelect/challenge/game/engine/processor/WormsRoundProcessorTest.kt
+++ b/game-engine/src/jvmTest/kotlin/za/co/entelect/challenge/game/engine/processor/WormsRoundProcessorTest.kt
@@ -420,6 +420,29 @@ class WormsRoundProcessorTest {
         assertEquals(expected, count.toInt())
     }
 
+    @Test
+    fun test_banana_score_destroyed_dirt() {
+        val aliceWorm = AgentWorm.build(0, config, Point(3, 2))
+        val alice = WormsPlayer.build(0, listOf(aliceWorm), config)
+
+        val bobWorm = AgentWorm.build(0, config, Point(2, 2))
+        val bob = WormsPlayer.build(1, listOf(bobWorm), config)
+
+        val map = buildMapWithCellType(listOf(bob, alice), 10, CellType.DIRT)
+        roundProcessor.processRound(map, commandMap(bob, alice,
+                        BananaCommand(Point(6, 3), config),
+                        DoNothingCommand(config)))
+
+        assertEquals(52, bob.commandScore, "Expected to gain 52 score from banana destroyed dirt cells")
+
+        roundProcessor.processRound(map, commandMap(bob, alice,
+                BananaCommand(Point(2, 6), config),
+                BananaCommand(Point(2, 6), config)))
+
+        assertEquals(104, bob.commandScore, "Expected to gain 104 score from banana destroyed dirt cells")
+        assertEquals(52, alice.commandScore, "Expected to gain 52 score from banana destroyed dirt cells")
+    }
+
     private fun commandMap(player1: WormsPlayer, player2: WormsPlayer, command1: WormsCommand, command2: WormsCommand = command1) =
             mapOf(Pair(player1, listOf(command1)), Pair(player2, listOf(command2)))
 


### PR DESCRIPTION
fix #67

When banana bombs destroy dirt block, the responsible player gets some points

When both player throw a banana bomb onto the same cell in the same round, only the first explosion granted score, since the dirt is already destroyed by the time the 2nd command is executed

Fixed to give both players score as if both were first to hit