### PR TITLE
Fix players unfairly penalised for friendly fire kills

### DIFF
--- a/game-engine/src/commonMain/kotlin/za/co/entelect/challenge/game/engine/map/WormsMap.kt
+++ b/game-engine/src/commonMain/kotlin/za/co/entelect/challenge/game/engine/map/WormsMap.kt
@@ -175,17 +175,15 @@ class WormsMap(override val players: List<WormsPlayer>,
     override fun setScoresForKilledWorms(config: GameConfig) {
         players.flatMap { it.worms }
                 .filter { it.dead && it.lastAttackedBy.any() }
-                .forEach { worm ->
-                    worm.lastAttackedBy
-                            .distinct()
-                            .forEach { attacker ->
-                                when (attacker) {
-                                    worm.player -> attacker.commandScore -= config.scores.killShot
-                                    else -> attacker.commandScore += config.scores.killShot
-                                }
-                            }
-                    worm.lastAttackedBy.clear()
+                .flatMap { worm -> worm.lastAttackedBy.distinct().map { attacker -> Pair(worm, attacker) } }
+                .forEach { (worm, attacker) ->
+                    when (attacker) {
+                        worm.player -> attacker.commandScore -= config.scores.killShot
+                        else -> attacker.commandScore += config.scores.killShot
+                    }
                 }
+
+        players.flatMap { it.worms }.forEach { it.lastAttackedBy.clear() }
     }
 
     override fun getVisualizerEvents(): List<VisualizerEvent> {

--- a/game-engine/src/jvmTest/kotlin/za/co/entelect/challenge/game/engine/player/WormTest.kt
+++ b/game-engine/src/jvmTest/kotlin/za/co/entelect/challenge/game/engine/player/WormTest.kt
@@ -1,7 +1,11 @@
 package za.co.entelect.challenge.game.engine.player
 
 import za.co.entelect.challenge.game.delegate.factory.TEST_CONFIG
+import za.co.entelect.challenge.game.engine.command.WormsCommand
 import za.co.entelect.challenge.game.engine.command.implementation.BananaCommand
+import za.co.entelect.challenge.game.engine.command.implementation.Direction
+import za.co.entelect.challenge.game.engine.command.implementation.DoNothingCommand
+import za.co.entelect.challenge.game.engine.command.implementation.ShootCommand
 import za.co.entelect.challenge.game.engine.factory.TestMapFactory
 import za.co.entelect.challenge.game.engine.map.CellType
 import za.co.entelect.challenge.game.engine.map.Point
@@ -11,6 +15,7 @@ import za.co.entelect.challenge.game.engine.player.WormsPlayer
 import za.co.entelect.challenge.game.engine.processor.WormsRoundProcessor
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class WormTest {
 
@@ -66,6 +71,42 @@ class WormTest {
         assertEquals(targetPlayer.commandScore, -60)
         assertEquals(attackingPlayer.commandScore, 60)
         assertEquals(victimWorm.health, -31)
+    }
+
+    @Test
+    fun test_friendly_fire_killshot_on_after_rounds() {
+        val targetCoordinate = Point(1, 1)
+        val victimWorm = CommandoWorm.build(0, config, targetCoordinate)
+
+        val traitorWorm = AgentWorm.build(0, config, Point(4, 1))
+        val targetWorms = listOf(traitorWorm, victimWorm)
+        val targetPlayer = WormsPlayer.build(0, targetWorms, config)
+
+        val attackerWorm = AgentWorm.build(0, config, Point(1, 3))
+        val attackingPlayer = WormsPlayer.build(1, listOf(attackerWorm), config)
+
+        val testMap = TestMapFactory.buildMapWithCellType(listOf(attackingPlayer, targetPlayer), 5, CellType.AIR)
+
+        assertEquals(100, victimWorm.health, "Victim $victimWorm should have been unharmed at this point")
+        assertEquals(0, targetPlayer.commandScore, "Friendly fire player $targetPlayer should have 0 score at this point")
+        assertEquals(0, attackingPlayer.commandScore, "Attacking player $attackingPlayer should have 0 score at this point")
+        val processor = WormsRoundProcessor(config)
+        processor.processRound(testMap, mapOf(
+                Pair(targetPlayer, listOf(ShootCommand(Direction.LEFT, config))),
+                Pair(attackingPlayer, listOf(DoNothingCommand(config)))))
+
+        assertEquals(92, victimWorm.health, "Victim $victimWorm should have sustained ${traitorWorm.weapon.damage} damage by now")
+        assertEquals(-8, targetPlayer.commandScore, "Friendly fire player $targetPlayer should have -8 score for hitting their own worm")
+        assertEquals(0, attackingPlayer.commandScore, "Attacking player $attackingPlayer should have 0 score at this point, since they did nothing")
+
+        victimWorm.health = 1
+        processor.processRound(testMap, mapOf(
+                Pair(targetPlayer, listOf(DoNothingCommand(config))),
+                Pair(attackingPlayer, listOf(ShootCommand(Direction.UP, config)))))
+        assertTrue(victimWorm.dead, "Victim $victimWorm be dead")
+        // This is where friendly fire player used to get penalised for past mistakes, when they certainly did not kill their worm
+        assertEquals(-8, targetPlayer.commandScore, "Friendly fire player $targetPlayer should have -8 score for hitting their own worm")
+        assertEquals(40 + 8, attackingPlayer.commandScore, "Attacking player $attackingPlayer should have 48 score at this point, since they did nothing")
     }
 
 }


### PR DESCRIPTION
Fix #72 

Add test to check for out of rounds killshot situations

Player 1 does friendly fire on round 1, but doesn't kill the worm
a few rounds later, Player 2 kills the worm from Player 1.

At this point, the game engine sees that the victim worm has a list of "last attacked by"players, and Player 1 is in this list (because of the old friendly fire)

This now gets cleared every round, for every worm after calculating killshots