### PR TITLE
Fix selection while the current worm is frozen

### DIFF
--- a/game-engine/src/commonMain/kotlin/za/co/entelect/challenge/game/engine/command/CommandExecutor.kt
+++ b/game-engine/src/commonMain/kotlin/za/co/entelect/challenge/game/engine/command/CommandExecutor.kt
@@ -27,7 +27,7 @@ class CommandExecutor(private val player: WormsPlayer,
             else -> player.consecutiveDoNothingsCount = 0
         }
 
-        if (worm.roundsUntilUnfrozen != freezeDuration && worm.roundsUntilUnfrozen > 0) {
+        if (!command.ignoresBeingFrozen() && worm.roundsUntilUnfrozen != freezeDuration && worm.roundsUntilUnfrozen > 0) {
             logger.info { "Tried to execute command $command, but $worm is still frozen for ${worm.roundsUntilUnfrozen} round" }
             map.addFeedback(StandardCommandFeedback(command.toString(), 0, player.id, false, "Frozen worms cannot follow your commands",
                     VisualizerEvent(CommandStrings.NOTHING.string, "frozen", worm, null, null, null)))

--- a/game-engine/src/commonMain/kotlin/za/co/entelect/challenge/game/engine/command/WormsCommand.kt
+++ b/game-engine/src/commonMain/kotlin/za/co/entelect/challenge/game/engine/command/WormsCommand.kt
@@ -22,5 +22,13 @@ interface WormsCommand {
      */
     fun execute(gameMap: WormsMap, worm: Worm): CommandFeedback
 
+    /**
+     * Produce true if the command should be executed regardless
+     * of whether the current worm is frozen.
+     */
+    fun ignoresBeingFrozen(): Boolean {
+        return false
+    }
+
     override fun toString(): String
 }

--- a/game-engine/src/commonMain/kotlin/za/co/entelect/challenge/game/engine/command/implementation/SelectCommand.kt
+++ b/game-engine/src/commonMain/kotlin/za/co/entelect/challenge/game/engine/command/implementation/SelectCommand.kt
@@ -41,6 +41,10 @@ class SelectCommand(val wormId: Int) : WormsCommand {
         }
     }
 
+    override fun ignoresBeingFrozen(): Boolean {
+        return true
+    }
+
     override fun toString(): String = "${CommandStrings.SELECT.string} $wormId"
 
 }

--- a/game-engine/src/jvmTest/kotlin/za/co/entelect/challenge/game/engine/command/CommandExecutorTest.kt
+++ b/game-engine/src/jvmTest/kotlin/za/co/entelect/challenge/game/engine/command/CommandExecutorTest.kt
@@ -6,6 +6,7 @@ import za.co.entelect.challenge.game.delegate.factory.TEST_CONFIG
 import za.co.entelect.challenge.game.engine.command.feedback.StandardCommandFeedback
 import za.co.entelect.challenge.game.engine.command.feedback.CommandValidation
 import za.co.entelect.challenge.game.engine.factory.TestMapFactory.buildMapWithCellType
+import za.co.entelect.challenge.game.engine.command.implementation.SelectCommand
 import za.co.entelect.challenge.game.engine.map.CellType
 import za.co.entelect.challenge.game.engine.map.Point
 import za.co.entelect.challenge.game.engine.player.CommandoWorm
@@ -37,6 +38,19 @@ class CommandExecutorTest {
         assertEquals(config.scores.invalidCommand * 2, player.commandScore)
 
         verify(command, times(0)).execute(any(), any())
+    }
+
+    @Test
+    fun test_selectFrozenWorm() {
+        val worms = listOf(CommandoWorm.build(0, config, Point(1, 1)),
+                CommandoWorm.build(1, config, Point(1, 2)))
+        worms[0].setAsFrozen(3)
+        val player = WormsPlayer.build(1, worms, config)
+        val command = SelectCommand(1)
+        val executor = CommandExecutor(player, mockMap, command, config)
+
+        executor.execute()
+        assertEquals(worms[1], player.currentWorm)
     }
 
     @Test


### PR DESCRIPTION
Hi all.

This should fix #85, which is the bug I reported regarding frozen worms.
This should make the engine behave as documented: https://github.com/EntelectChallenge/2019-Worms/blob/develop/game-engine/game-rules.md#snowball

> You can still successfully issue a Select command to use a different worm

I've gone about it by adding a method to all commands which determines whether the command can be executed regardless of whether the current worm is frozen.

To test it I've had to pull SelectCommand into the CommandExecutor test.
It looks like you were trying to keep them out of the test, but this is a cross cutting concern.
The executor gets to choose what gets run and selects are a special case.