### PR TITLE
Feature/current worm dead

### DIFF
--- a/game-engine/build.gradle.kts
+++ b/game-engine/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 }
 
 group = "za.co.entelect.challenge"
-version = "2019.3.1"
+version = "2019.3.2"
 
 repositories {
     mavenLocal()

--- a/game-engine/src/commonMain/kotlin/za/co/entelect/challenge/game/engine/player/WormsPlayer.kt
+++ b/game-engine/src/commonMain/kotlin/za/co/entelect/challenge/game/engine/player/WormsPlayer.kt
@@ -46,8 +46,8 @@ class WormsPlayer private constructor(val id: Int,
         //Assign living worms to a local variable since it is a computed property
         val livingWorms = this.livingWorms
         if (livingWorms.isNotEmpty()) {
-            val nextIndex = (livingWorms.indexOf(currentWorm) + 1) % livingWorms.size
-            updateCurrentWorm(livingWorms[nextIndex])
+            val nextWorm = livingWorms.firstOrNull { it.id > currentWorm.id } ?: livingWorms.first()
+            updateCurrentWorm(nextWorm)
         }
     }
 

--- a/game-engine/src/jvmTest/kotlin/za/co/entelect/challenge/game/engine/player/WormsPlayerTest.kt
+++ b/game-engine/src/jvmTest/kotlin/za/co/entelect/challenge/game/engine/player/WormsPlayerTest.kt
@@ -50,6 +50,32 @@ class WormsPlayerTest {
     }
 
     @Test
+    fun test_player_wormSelection_All() {
+        val player = WormsPlayer.build(2, config)
+        assertEquals(1, player.currentWorm.id)
+
+        player.selectNextWorm()
+        assertEquals(player.worms[1], player.currentWorm)
+        assertEquals(2, player.currentWorm.id)
+
+        player.selectNextWorm()
+        assertEquals(player.worms[2], player.currentWorm)
+        assertEquals(3, player.currentWorm.id)
+
+        player.selectNextWorm()
+        assertEquals(player.worms[0], player.currentWorm)
+        assertEquals(1, player.currentWorm.id)
+
+        player.selectNextWorm()
+        assertEquals(player.worms[1], player.currentWorm)
+        assertEquals(2, player.currentWorm.id)
+
+        player.selectNextWorm()
+        assertEquals(player.worms[2], player.currentWorm)
+        assertEquals(3, player.currentWorm.id)
+    }
+
+    @Test
     fun test_player_wormSelection_currentWormDead() {
         val player = WormsPlayer.build(2, config)
 

--- a/game-engine/src/jvmTest/kotlin/za/co/entelect/challenge/game/engine/player/WormsPlayerTest.kt
+++ b/game-engine/src/jvmTest/kotlin/za/co/entelect/challenge/game/engine/player/WormsPlayerTest.kt
@@ -50,6 +50,20 @@ class WormsPlayerTest {
     }
 
     @Test
+    fun test_player_wormSelection_currentWormDead() {
+        val player = WormsPlayer.build(2, config)
+
+        player.updateCurrentWorm(player.worms[1])
+        player.worms[1].health = 0;
+
+        assertEquals(2, player.currentWorm.id);
+
+        player.selectNextWorm();
+
+        assertEquals(3, player.currentWorm.id)
+    }
+
+    @Test
     fun test_player_dead() {
         val player = WormsPlayer.build(0, config)
         player.worms.forEachIndexed { i, worm -> worm.health = -i }


### PR DESCRIPTION
Fix bug where the next current worm is incorrectly selected if the current worm dies.

Closes #84 